### PR TITLE
Add Register button

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -10,6 +10,7 @@ from preprocessing import (
 )
 from register import get_base_plan, perform_registration
 from tkinter import messagebox
+from tkinter import ttk
 from resampling import resample_ct
 from utils import load_environment, check_if_ct_present, find_series_uids
 from segmentation import create_empty_rtstruct
@@ -160,10 +161,13 @@ def main():
 
     # Register button
     register_status = tk.Label(root, text="", font=("Helvetica", 14))
+    register_progress = ttk.Progressbar(root, length=200, mode="determinate")
 
     def on_register():
         register_status.config(text="\u23F3", fg="orange")
         root.update_idletasks()
+        register_progress["value"] = 0
+        register_progress.grid()
         try:
             dicom_series = find_series_uids(str(input_dir))
             for series_uid, filepaths in dicom_series.items():
@@ -178,14 +182,29 @@ def main():
                 rigid_transform = None
 
             if rigid_transform:
-                copy_structures(str(input_dir), patient_id, rtplan_label, rigid_transform)
+                def progress_cb(idx, total):
+                    register_progress["maximum"] = total
+                    register_progress["value"] = idx
+                    root.update_idletasks()
+
+                copy_structures(
+                    str(input_dir),
+                    patient_id,
+                    rtplan_label,
+                    rigid_transform,
+                    progress_callback=progress_cb,
+                )
             register_status.config(text="\u2705", fg="green")
         except Exception:
             register_status.config(text="\u274C", fg="red")
+        finally:
+            register_progress.grid_remove()
 
     btn_register = tk.Button(root, text="Register", command=on_register)
     btn_register.grid(row=9, column=0, sticky="w", padx=10, pady=(0, 10))
     register_status.grid(row=9, column=1, sticky="w")
+    register_progress.grid(row=10, column=0, columnspan=2, sticky="w", padx=10, pady=(0, 10))
+    register_progress.grid_remove()
 
     def update_dropdown(*args):
         # get all selected series

--- a/gui.py
+++ b/gui.py
@@ -9,6 +9,7 @@ from preprocessing import (
     process_single_dicom_file,
 )
 from register import get_base_plan, perform_registration
+from tkinter import messagebox
 from resampling import resample_ct
 from utils import load_environment, check_if_ct_present, find_series_uids
 from segmentation import create_empty_rtstruct
@@ -168,8 +169,11 @@ def main():
             for series_uid, filepaths in dicom_series.items():
                 create_empty_rtstruct(str(input_dir), series_uid, filepaths)
 
+            def confirm():
+                return messagebox.askyesno("Registration", "Accept registration result?")
+
             try:
-                rigid_transform = perform_registration(str(input_dir), patient_id, rtplan_label)
+                rigid_transform = perform_registration(str(input_dir), patient_id, rtplan_label, confirm_fn=confirm)
             except Exception:
                 rigid_transform = None
 

--- a/register.py
+++ b/register.py
@@ -491,7 +491,7 @@ def run_viewer(fixed_image, moving_image):
     overlay = MultiViewOverlay(fixed_array, moving_array)
     return overlay.shift_z
 
-def perform_registration(current_directory, patient_id, rtplan_label):
+def perform_registration(current_directory, patient_id, rtplan_label, confirm_fn=None):
     fixed_dir = current_directory
     baseplan_dir = Path(os.environ.get('BASEPLAN_DIR'))
     moving_dir = baseplan_dir / patient_id / rtplan_label
@@ -553,9 +553,12 @@ def perform_registration(current_directory, patient_id, rtplan_label):
     print(f"Rigid translation: {translation}")
     run_viewer(fixed_image, moving_reg)
 
-    registration_accepted = input("Registration accepted? (y/n): ")
+    if confirm_fn is None:
+        registration_accepted = input("Registration accepted? (y/n): ") == "y"
+    else:
+        registration_accepted = confirm_fn()
 
-    if registration_accepted == "y":
+    if registration_accepted:
         print(f"{get_datetime()} Registration accepted")
         # In this implementation the transform is inverted inside transformation_matrix()
         # so we pass rigid_transform as is.


### PR DESCRIPTION
## Summary
- add missing imports for registration workflow
- add Register button after the Resample button to run registration steps

## Testing
- `pytest -q`
- `python -m py_compile gui.py`


------
https://chatgpt.com/codex/tasks/task_e_685442b49514832f8388a788a8998403