### PR TITLE
Reorder backup button

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -150,13 +150,6 @@ def main():
     btn_images.grid(row=4, column=0, sticky="w", padx=10, pady=(0, 5))
     images_status.grid(row=4, column=1, sticky="w")
 
-    # Imaging series frame (initially empty)
-    series_frame = tk.Frame(root)
-    series_frame.grid(row=5, column=0, columnspan=2, sticky="w", padx=10, pady=10)
-
-    # Dropdown menu for registration series
-    selected_var = tk.StringVar()
-    selection_map = {}
     # Backup button (create backup of input directory)
     backup_status = tk.Label(root, text="", font=("Helvetica", 14))
 
@@ -170,8 +163,16 @@ def main():
             backup_status.config(text="\u274C", fg="red")
 
     btn_backup = tk.Button(root, text="Create backup", command=on_backup)
-    btn_backup.grid(row=6, column=0, sticky="w", padx=10)
-    backup_status.grid(row=6, column=1, sticky="w")
+    btn_backup.grid(row=5, column=0, sticky="w", padx=10)
+    backup_status.grid(row=5, column=1, sticky="w")
+
+    # Imaging series frame (initially empty)
+    series_frame = tk.Frame(root)
+    series_frame.grid(row=6, column=0, columnspan=2, sticky="w", padx=10, pady=10)
+
+    # Dropdown menu for registration series
+    selected_var = tk.StringVar()
+    selection_map = {}
 
     tk.Label(root, text="Select Series for Matching").grid(row=7, column=0, columnspan=2, sticky="w", padx=10)
     dropdown = tk.OptionMenu(root, selected_var, '')

--- a/gui.py
+++ b/gui.py
@@ -170,13 +170,6 @@ def main():
     series_frame = tk.Frame(root)
     series_frame.grid(row=6, column=0, columnspan=2, sticky="w", padx=10, pady=10)
 
-    # Dropdown menu for registration series
-    selected_var = tk.StringVar()
-    selection_map = {}
-
-    tk.Label(root, text="Select Series for Matching").grid(row=7, column=0, columnspan=2, sticky="w", padx=10)
-    dropdown = tk.OptionMenu(root, selected_var, '')
-    dropdown.grid(row=8, column=0, columnspan=2, sticky="w", padx=10, pady=(0, 10))
 
     # Clean up button
     cleanup_status = tk.Label(root, text="", font=("Helvetica", 14))
@@ -223,6 +216,14 @@ def main():
     btn_resample.grid(row=10, column=0, sticky="w", padx=10, pady=(0, 10))
     resample_status.grid(row=10, column=1, sticky="w")
 
+    # Dropdown menu for registration series
+    selected_var = tk.StringVar()
+    selection_map = {}
+
+    tk.Label(root, text="Select Series for Matching").grid(row=11, column=0, columnspan=2, sticky="w", padx=10)
+    dropdown = tk.OptionMenu(root, selected_var, '')
+    dropdown.grid(row=12, column=0, columnspan=2, sticky="w", padx=10, pady=(0, 10))
+
     # Register button
     register_status = tk.Label(root, text="", font=("Helvetica", 14))
     register_progress = ttk.Progressbar(root, length=200, mode="determinate")
@@ -265,9 +266,9 @@ def main():
             register_progress.grid_remove()
 
     btn_register = tk.Button(root, text="Register", command=on_register)
-    btn_register.grid(row=11, column=0, sticky="w", padx=10, pady=(0, 10))
-    register_status.grid(row=11, column=1, sticky="w")
-    register_progress.grid(row=12, column=0, columnspan=2, sticky="w", padx=10, pady=(0, 10))
+    btn_register.grid(row=13, column=0, sticky="w", padx=10, pady=(0, 10))
+    register_status.grid(row=13, column=1, sticky="w")
+    register_progress.grid(row=14, column=0, columnspan=2, sticky="w", padx=10, pady=(0, 10))
     register_progress.grid_remove()
 
     def update_dropdown(*args):

--- a/gui.py
+++ b/gui.py
@@ -157,11 +157,7 @@ def main():
     # Dropdown menu for registration series
     selected_var = tk.StringVar()
     selection_map = {}
-    tk.Label(root, text="Select Series for Matching").grid(row=6, column=0, columnspan=2, sticky="w", padx=10)
-    dropdown = tk.OptionMenu(root, selected_var, '')
-    dropdown.grid(row=7, column=0, columnspan=2, sticky="w", padx=10, pady=(0, 10))
-
-    # Backup button under the dropdown
+    # Backup button (create backup of input directory)
     backup_status = tk.Label(root, text="", font=("Helvetica", 14))
 
     def on_backup():
@@ -174,8 +170,12 @@ def main():
             backup_status.config(text="\u274C", fg="red")
 
     btn_backup = tk.Button(root, text="Create backup", command=on_backup)
-    btn_backup.grid(row=8, column=0, sticky="w", padx=10)
-    backup_status.grid(row=8, column=1, sticky="w")
+    btn_backup.grid(row=6, column=0, sticky="w", padx=10)
+    backup_status.grid(row=6, column=1, sticky="w")
+
+    tk.Label(root, text="Select Series for Matching").grid(row=7, column=0, columnspan=2, sticky="w", padx=10)
+    dropdown = tk.OptionMenu(root, selected_var, '')
+    dropdown.grid(row=8, column=0, columnspan=2, sticky="w", padx=10, pady=(0, 10))
 
     # Clean up button
     cleanup_status = tk.Label(root, text="", font=("Helvetica", 14))


### PR DESCRIPTION
## Summary
- move backup button to sit above the series selection dropdown in the GUI

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68558d812c74832f9914d544cd2029b0