### PR TITLE
Add deformable registration after rigid step

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # tb-adaption-dev
+
+This project provides tools for registering and preprocessing medical image
+data.  Registration now includes a deformable step following the rigid
+registration to improve alignment of CT-to-CT and MR T2-to-T2 images.
  


### PR DESCRIPTION
## Summary
- add a BSpline-based deformable registration step following the rigid registration
- save registration result as a composite transform while DICOM REG stores the rigid part only
- document new deformable registration in README

## Testing
- `python -m py_compile register.py copy_structures.py gui.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_685be92a2574832f969ea72c154950b3