### PR TITLE
Use NCC metric for registration

### DIFF
--- a/register.py
+++ b/register.py
@@ -145,14 +145,14 @@ def perform_rigid_registration(fixed_image, moving_image, initial_transform):
     # )
 
     registration_method = sitk.ImageRegistrationMethod()
-    registration_method.SetMetricAsMattesMutualInformation(numberOfHistogramBins=50)
+    registration_method.SetMetricAsCorrelation()
     registration_method.SetMetricSamplingStrategy(registration_method.RANDOM)
-    registration_method.SetMetricSamplingPercentage(0.02, seed=42)
+    registration_method.SetMetricSamplingPercentage(0.1, seed=42)
     registration_method.SetInterpolator(sitk.sitkLinear)
     registration_method.SetOptimizerAsRegularStepGradientDescent(
         learningRate=1.0,
         minStep=1e-6,
-        numberOfIterations=100,  # change back to 300?
+        numberOfIterations=200,
         gradientMagnitudeTolerance=1e-6
     )
     registration_method.SetOptimizerScalesFromPhysicalShift()


### PR DESCRIPTION
## Summary
- use normalized cross-correlation metric
- sample 10% of voxels during optimization
- increase optimizer iterations to 200

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bf0410320832fa89db2979ff2f821