### PR TITLE
Ensure RTSTRUCT selection matches registered series

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -293,7 +293,7 @@ def main():
             bp_modality = bp_info.get("modality")
 
             try:
-                rigid_transform = perform_registration(
+                rigid_transform, used_fixed_uid, used_moving_uid = perform_registration(
                     str(input_dir),
                     patient_id,
                     rtplan_label,
@@ -304,7 +304,7 @@ def main():
                     confirm_fn=confirm,
                 )
             except Exception:
-                rigid_transform = None
+                rigid_transform, used_fixed_uid, used_moving_uid = None, None, None
 
             if rigid_transform:
                 def progress_cb(idx, total):
@@ -317,7 +317,8 @@ def main():
                     patient_id,
                     rtplan_label,
                     rigid_transform,
-                    series_uid=selected_uid,
+                    series_uid=used_fixed_uid,
+                    base_series_uid=used_moving_uid,
                     progress_callback=progress_cb,
                 )
             register_status.config(text="\u2705", fg="green")

--- a/main.py
+++ b/main.py
@@ -88,16 +88,17 @@ def main():
     print()
     print(f"{get_datetime()} Performing registration".upper())
     try:
-        rigid_transform = perform_registration(current_directory, patient_id, rtplan_label)
+        rigid_transform, fixed_uid, moving_uid = perform_registration(current_directory, patient_id, rtplan_label)
     except Exception:
         print(f"{get_datetime()} Registration failed")
-        rigid_transform = None
+        rigid_transform, fixed_uid, moving_uid = None, None, None
 
     # Step 5: Copy structures from the base plan to the new image
     print()
     print(f"{get_datetime()} Copying structures".upper())
     if rigid_transform:
-        copy_structures(current_directory, patient_id, rtplan_label, rigid_transform)
+        copy_structures(current_directory, patient_id, rtplan_label, rigid_transform,
+                        series_uid=fixed_uid, base_series_uid=moving_uid)
     else:
         print(f"{get_datetime()} No registration performed -> no structures copied")
 


### PR DESCRIPTION
## Summary
- link RTSTRUCT files to the selected series for copying
- propagate used series UID from registration
- use these UIDs when copying structures

## Testing
- `python -m py_compile copy_structures.py register.py main.py gui.py`

------
https://chatgpt.com/codex/tasks/task_e_685bfe5a6aec832f9d458bf68d7f0fb0