### PR TITLE
Adapt registration metric based on modalities

### DIFF
--- a/register.py
+++ b/register.py
@@ -124,7 +124,19 @@ def extract_metadata(dicom_file):
     meta['StudyID'] = ds.get("StudyID", "Anonymous")
     return meta
 
-def perform_rigid_registration(fixed_image, moving_image, initial_transform):
+def perform_rigid_registration(
+    fixed_image,
+    moving_image,
+    initial_transform,
+    fixed_modality="CT",
+    moving_modality="CT",
+):
+    """Perform rigid registration of two images.
+
+    The metric is chosen automatically based on modality:
+    cross-correlation for same-modality pairs and mutual information for
+    cross-modality pairs.
+    """
     print(f"{get_datetime()} Initializing registration...")
 
     # Clip intensities to [-160, 240] to reduce outliers
@@ -148,7 +160,13 @@ def perform_rigid_registration(fixed_image, moving_image, initial_transform):
         )
 
     registration_method = sitk.ImageRegistrationMethod()
-    registration_method.SetMetricAsCorrelation()
+    # Use correlation for same-modality registrations, mutual information
+    # otherwise. Mutual information is more robust for MR-CT registrations
+    # where intensities do not correspond directly.
+    if fixed_modality == moving_modality:
+        registration_method.SetMetricAsCorrelation()
+    else:
+        registration_method.SetMetricAsMattesMutualInformation(50)
     registration_method.SetMetricSamplingStrategy(registration_method.RANDOM)
     registration_method.SetMetricSamplingPercentage(0.01, seed=42)
     registration_method.SetInterpolator(sitk.sitkLinear)
@@ -707,7 +725,13 @@ def perform_registration(current_directory, patient_id, rtplan_label,
     # run_viewer(fixed_image, moving_reg)
 
     # Rigid registration
-    rigid_transform = perform_rigid_registration(fixed_image, moving_image, initial_transform)
+    rigid_transform = perform_rigid_registration(
+        fixed_image,
+        moving_image,
+        initial_transform,
+        fixed_modality=fixed_modality,
+        moving_modality=moving_modality,
+    )
 
     # Resample for visual check
     moving_reg = sitk.Resample(moving_image, fixed_image, rigid_transform,


### PR DESCRIPTION
## Summary
- choose the registration metric automatically based on input modalities
  - correlation for same-modality registrations
  - mutual information for cross-modality registrations
- propagate modality info when calling `perform_rigid_registration`

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile register.py`
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_686fad62dedc832f829159dfedfaa954