### PR TITLE
Fix reset clearing copy structures status

### DIFF
--- a/run_gui.py
+++ b/run_gui.py
@@ -469,6 +469,7 @@ def main():
             resample_status,
             rename_status,
             register_status,
+            copy_status,
         ):
             lbl.config(text="")
         register_progress.grid_remove()


### PR DESCRIPTION
## Summary
- clear the copy structures status label when clicking **Reset**

## Testing
- `python -m py_compile run_gui.py`

------
https://chatgpt.com/codex/tasks/task_e_686e5e43ec94832fb62e03f10f606601