### PR TITLE
Configure SimpleITK threading

### DIFF
--- a/main.py
+++ b/main.py
@@ -12,7 +12,13 @@ from preprocessing import preprocess_input_directory, check_input_directory
 from register import perform_registration, get_base_plan
 from resampling import resample_ct
 from segmentation import create_empty_rtstruct
-from utils import get_datetime, find_series_uids, check_if_ct_present, load_environment
+from utils import (
+    get_datetime,
+    find_series_uids,
+    check_if_ct_present,
+    load_environment,
+    configure_sitk_threads,
+)
 
 warnings.filterwarnings("ignore", category=UserWarning, module="pydicom")
 
@@ -29,6 +35,7 @@ def main():
 
     # Load the .env
     load_environment(".env")
+    configure_sitk_threads()
 
     # Production
     patient_id = sys.argv[1]

--- a/register.py
+++ b/register.py
@@ -11,7 +11,7 @@ from pydicom.sequence import Sequence
 from pydicom.uid import generate_uid, ExplicitVRLittleEndian
 import matplotlib.pyplot as plt
 from matplotlib.widgets import Slider
-from utils import get_datetime, load_environment
+from utils import get_datetime, load_environment, configure_sitk_threads
 
 from dbconnector import DBHandler
 
@@ -20,6 +20,7 @@ from dbconnector import DBHandler
 # --------------------------------------------------------------------
 
 load_environment(".env")
+configure_sitk_threads()
 
 def get_base_plan(patient_id, rtplan_label, rtplan_uid):
     baseplan_dir = Path(os.environ.get('BASEPLAN_DIR'))
@@ -817,3 +818,4 @@ def perform_registration(current_directory, patient_id, rtplan_label,
     else:
         print(f"{get_datetime()} Registration rejected")
         return None, None, None
+

--- a/run_gui.py
+++ b/run_gui.py
@@ -15,7 +15,12 @@ from register import get_base_plan, perform_registration
 from tkinter import messagebox
 from tkinter import ttk
 from resampling import resample_ct
-from utils import load_environment, check_if_ct_present, find_series_uids
+from utils import (
+    load_environment,
+    check_if_ct_present,
+    find_series_uids,
+    configure_sitk_threads,
+)
 from segmentation import create_empty_rtstruct
 from copy_structures import copy_structures, _rtstruct_references_series
 
@@ -95,6 +100,7 @@ def get_patient_name(directory_path: str) -> str:
 
 def main():
     load_environment(".env")
+    configure_sitk_threads()
     try:
         patient_id = sys.argv[1]
         rtplan_label = sys.argv[2]
@@ -520,3 +526,4 @@ def main():
 
 if __name__ == '__main__':
     main()
+

--- a/utils.py
+++ b/utils.py
@@ -92,3 +92,16 @@ def load_environment(env_file_path: str = ".env"):
         base_dir = os.path.dirname(os.path.abspath(__file__))
     dotenv_path = os.path.join(base_dir, env_file_path)
     load_dotenv(dotenv_path)
+
+
+def configure_sitk_threads():
+    """Configure SimpleITK to use all CPU cores."""
+    try:
+        import multiprocessing
+        import SimpleITK as sitk
+        n_threads = multiprocessing.cpu_count()
+        sitk.ProcessObject.SetGlobalDefaultNumberOfThreads(n_threads)
+        print(f"Using {n_threads} SimpleITK threads")
+    except Exception as exc:
+        print(f"Could not configure SimpleITK threads: {exc}")
+


### PR DESCRIPTION
## Summary
- configure SimpleITK to use all CPU cores
- make `configure_sitk_threads` available in utils
- apply it in `main.py`, `run_gui.py`, and `register.py`
- log the number of threads when configuring SimpleITK

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686fd4e6e73c832fa5ca834b1242c773