### PR TITLE
Improve registration mode dialog layout

### DIFF
--- a/run_gui.py
+++ b/run_gui.py
@@ -358,6 +358,11 @@ def main():
         btn_semi.pack(padx=10, pady=(0, 10))
 
         dialog.transient(root)
+        # Center the dialog on the screen
+        dialog.update_idletasks()
+        x = (dialog.winfo_screenwidth() // 2) - (dialog.winfo_width() // 2)
+        y = (dialog.winfo_screenheight() // 2) - (dialog.winfo_height() // 2)
+        dialog.geometry(f"+{x}+{y}")
         dialog.grab_set()
         root.wait_window(dialog)
         return result["mode"]


### PR DESCRIPTION
## Summary
- center the registration mode dialog on screen

## Testing
- `python -m py_compile run_gui.py`


------
https://chatgpt.com/codex/tasks/task_e_6878f9c85178832f8ee4be36f43bb3c3