### PR TITLE
Show selected imaging series only

### DIFF
--- a/run_gui.py
+++ b/run_gui.py
@@ -547,7 +547,15 @@ def main():
         menu = dropdown["menu"]
         menu.delete(0, 'end')
         selection_map.clear()
-        filtered_uids = [uid for uid, info in series_info.items() if info.get('modality') in ('CT', 'MR')]
+        filtered_uids = [
+            uid
+            for uid, info in series_info.items()
+            if info.get('modality') in ('CT', 'MR')
+            and (
+                info.get('description', '').startswith('t2_tse_tra')
+                or info.get('description', '').startswith('sCT_sp')
+            )
+        ]
         for uid in filtered_uids:
             info = series_info[uid]
             text = checkbox_texts.get(uid, info['description'])


### PR DESCRIPTION
## Summary
- filter dropdown menu for series selection to only show imaging series with descriptions starting with `t2_tse_tra` or `sCT_sp`

## Testing
- `python -m py_compile run_gui.py`


------
https://chatgpt.com/codex/tasks/task_e_68827ccbbf98832fb7c6c4e165936f24