### PR TITLE
Delete files after successful send to Aria

### DIFF
--- a/export.py
+++ b/export.py
@@ -78,10 +78,9 @@ def send_files_to_aria(filepaths, progress_callback=None):
         status = send_file(assoc, ds)
         if status and status.Status == 0x0000:
             try:
-                pass
-                # os.remove(fpath)
-            except Exception:
-                pass
+                os.remove(fpath)
+            except Exception as exc:
+                print(f"Failed to delete file {fpath}: {exc}")
         else:
             print(f"Failed to send file: {fpath}")
             success = False


### PR DESCRIPTION
## Summary
- Remove files after they are successfully sent via DICOM association
- Log an error if deletion fails

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a46b9e965c832fbdfadc29d492d348