### PR TITLE
Add CSV logging for registration metrics

### DIFF
--- a/register.py
+++ b/register.py
@@ -1,4 +1,5 @@
 import datetime
+import csv
 import os
 import socket
 import time
@@ -29,6 +30,31 @@ from copy_structures import read_base_rtstruct
 
 load_environment(".env")
 configure_sitk_threads()
+
+LOG_FILE = Path(__file__).resolve().parent / "registration_log.csv"
+
+def _log_registration_entry(entry):
+    """Append a registration entry to the CSV log."""
+    headers = [
+        "patient_id",
+        "rtplan_label",
+        "timestamp",
+        "fixed_series_description",
+        "moving_series_description",
+        "registration_type",
+        "cost_function",
+        "initial_transform",
+        "fine_tuned_transform",
+        "final_transform",
+        "duration_seconds",
+        "accepted",
+    ]
+    file_exists = LOG_FILE.exists()
+    with LOG_FILE.open("a", newline="") as csvfile:
+        writer = csv.DictWriter(csvfile, fieldnames=headers)
+        if not file_exists:
+            writer.writeheader()
+        writer.writerow(entry)
 
 def get_base_plan(patient_id, rtplan_label, rtplan_uid):
     baseplan_dir = Path(os.environ.get('BASEPLAN_DIR'))
@@ -661,7 +687,8 @@ def perform_registration(current_directory, patient_id, rtplan_label,
     print(f"{get_datetime()} Final metric value: {metric_value:.4f}")
 
     end_time = time.time()
-    print(f"{get_datetime()} Registration took {end_time - start_time:.2f} seconds")
+    duration = end_time - start_time
+    print(f"{get_datetime()} Registration took {duration:.2f} seconds")
     print(f"{get_datetime()} DONE\n")
 
     run_viewer(
@@ -677,6 +704,24 @@ def perform_registration(current_directory, patient_id, rtplan_label,
         registration_accepted = input(prompt) == "y"
     else:
         registration_accepted = confirm_fn(metric_value)
+
+    log_entry = {
+        "patient_id": patient_id,
+        "rtplan_label": rtplan_label,
+        "timestamp": datetime.datetime.now().isoformat(),
+        "fixed_series_description": get_series_description(fixed_files[0]),
+        "moving_series_description": get_series_description(moving_files[0]),
+        "registration_type": "semi-automatic" if manual_fine_tuning else "automatic",
+        "cost_function": metric_value,
+        "initial_transform": ",".join(f"{v:.2f}" for v in prealign_transform.GetTranslation()),
+        "fine_tuned_transform": ",".join(f"{v:.2f}" for v in fine_tuned_transform.GetTranslation()),
+        "final_transform": ",".join(
+            f"{v:.2f}" for v in get_final_rigid_transform(rigid_transform).GetTranslation()
+        ),
+        "duration_seconds": round(duration, 2),
+        "accepted": registration_accepted,
+    }
+    _log_registration_entry(log_entry)
 
     if registration_accepted:
         print(f"{get_datetime()} Registration accepted")

--- a/register.py
+++ b/register.py
@@ -31,7 +31,7 @@ from copy_structures import read_base_rtstruct
 load_environment(".env")
 configure_sitk_threads()
 
-LOG_FILE = Path(__file__).resolve().parent / "registration_log.csv"
+LOG_FILE = Path(r"\\raoariaapps\raoariaapps$\Utilities\tb_adaption\registration_log.csv")
 
 def _log_registration_entry(entry):
     """Append a registration entry to the CSV log."""
@@ -629,6 +629,7 @@ def perform_registration(current_directory, patient_id, rtplan_label,
         iso_fixed,
         iso_moving,
     )
+    prealign_transform_translation = prealign_transform.GetTranslation()
 
     # Clamp intensities
     # iso_moving = sitk.Clamp(iso_moving, lowerBound=-160, upperBound=240)
@@ -637,7 +638,6 @@ def perform_registration(current_directory, patient_id, rtplan_label,
     # print(f"{get_datetime()} Baseline mutual information: {mi:.4f}")
 
     # Fine-tuning
-    fine_tuned_transform = sitk.VersorRigid3DTransform(prealign_transform)
     if manual_fine_tuning:
         fine_tuned_transform = tune_initial_registration(
             fixed_image,
@@ -713,7 +713,7 @@ def perform_registration(current_directory, patient_id, rtplan_label,
         "moving_series_description": get_series_description(moving_files[0]),
         "registration_type": "semi-automatic" if manual_fine_tuning else "automatic",
         "cost_function": metric_value,
-        "initial_transform": ",".join(f"{v:.2f}" for v in prealign_transform.GetTranslation()),
+        "initial_transform": ",".join(f"{v:.2f}" for v in prealign_transform_translation),
         "fine_tuned_transform": ",".join(f"{v:.2f}" for v in fine_tuned_transform.GetTranslation()),
         "final_transform": ",".join(
             f"{v:.2f}" for v in get_final_rigid_transform(rigid_transform).GetTranslation()


### PR DESCRIPTION
## Summary
- log registration metadata to `registration_log.csv`
- capture transforms, cost function, series descriptions, timing, and acceptance for each registration

## Testing
- `python -m py_compile register.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad81bb2d0c832fa4061f672b61901d