### PR TITLE
Ensure patient name metadata persists without extra rewrite

### DIFF
--- a/resampling.py
+++ b/resampling.py
@@ -162,10 +162,14 @@ def save_resampled_image_as_dicom(resampled_CT, input_folder, output_folder):
     # Generate a new Series Instance UID for the resampled output
     new_series_uid = generate_uid()
     # Series DICOM tags to copy
+    patient_name_value = get_dicom_value(original_CT_pydicom, Tag(0x00100010))
+    if patient_name_value not in (None, ""):
+        patient_name_value = str(patient_name_value)
+
     series_tag_values = [
         ("0008|0005", get_dicom_value(original_CT_pydicom, Tag(0x00080005))),  # Specific Character Set
         ("0018|0060", get_dicom_value(original_CT_pydicom, Tag(0x00180060))),  # kVp
-        ("0010|0010", get_dicom_value(original_CT_pydicom, Tag(0x00100010))),  # Patient Name
+        ("0010|0010", patient_name_value),  # Patient Name
         ("0010|0020", get_dicom_value(original_CT_pydicom, Tag(0x00100020))),  # Patient ID
         ("0010|0030", get_dicom_value(original_CT_pydicom, Tag(0x00100030))),  # Patient Birth Date
         ("0010|0040", get_dicom_value(original_CT_pydicom, Tag(0x00100040))),  # Patient Sex
@@ -234,10 +238,6 @@ def save_resampled_image_as_dicom(resampled_CT, input_folder, output_folder):
         local_writer.KeepOriginalImageUIDOn()
         local_writer.SetFileName(filename_save)
         local_writer.Execute(image_slice)
-
-        ds = pydicom.dcmread(filename_save)
-        ds.PatientName = get_dicom_value(original_CT_pydicom, Tag(0x00100010))
-        ds.save_as(filename_save)
 
     with ThreadPoolExecutor() as executor:
         list(executor.map(write_slice, range(resampled_CT.GetDepth())))


### PR DESCRIPTION
## Summary
- coerce the copied PatientName tag to a plain string before setting metadata
- rely solely on the SimpleITK writer now that it emits PatientName without an additional pydicom rewrite

## Testing
- python - <<'PY' ... (spot check script verifying PatientName)


------
https://chatgpt.com/codex/tasks/task_e_68d24d12ec8c832f9cea71f810a48bdb