### PR TITLE
Handle missing StudyDate when generating RTSTRUCT IDs

### DIFF
--- a/rtstruct_id.py
+++ b/rtstruct_id.py
@@ -1,6 +1,9 @@
 from datetime import datetime
 
 
+FALLBACK_DATE_STR = "unknown"
+
+
 def create_rtstruct_id(meta_data):
     """Generate a proposed ID based on the image modality and metadata."""
     modality = getattr(meta_data, "Modality", "")
@@ -90,8 +93,29 @@ def mr2id_suffix(comment):
 
 
 def datetime2yymmdd(date_str):
-    """Convert a datetime string to YY-MM-DD format."""
-    formatted_date = datetime.strptime(date_str, "%Y%m%d").strftime("%y-%m-%d")
-    # if len(in_datetime) >= 10:
-    #     return f"{in_datetime[8:10]}-{in_datetime[3:5]}-{in_datetime[0:2]}"
-    return datetime.strptime(date_str, "%Y%m%d").strftime("%y-%m-%d")
+    """Convert a datetime string to YY-MM-DD format.
+
+    Returns
+    -------
+    str
+        A string in the format ``YY-MM-DD`` if ``date_str`` can be parsed,
+        otherwise :data:`FALLBACK_DATE_STR`.
+    """
+
+    if isinstance(date_str, datetime):
+        return date_str.strftime("%y-%m-%d")
+
+    try:
+        cleaned = str(date_str).strip()
+    except Exception:
+        return FALLBACK_DATE_STR
+
+    if not cleaned:
+        return FALLBACK_DATE_STR
+
+    try:
+        parsed = datetime.strptime(cleaned, "%Y%m%d")
+    except (TypeError, ValueError):
+        return FALLBACK_DATE_STR
+
+    return parsed.strftime("%y-%m-%d")

--- a/tests/test_rtstruct_id.py
+++ b/tests/test_rtstruct_id.py
@@ -1,0 +1,21 @@
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from rtstruct_id import FALLBACK_DATE_STR, create_rtstruct_id, datetime2yymmdd
+
+
+def test_datetime2yymmdd_returns_fallback_for_invalid_values():
+    assert datetime2yymmdd("") == FALLBACK_DATE_STR
+    assert datetime2yymmdd(None) == FALLBACK_DATE_STR
+    assert datetime2yymmdd("notadate") == FALLBACK_DATE_STR
+
+
+def test_create_rtstruct_id_handles_missing_study_date():
+    metadata = SimpleNamespace(
+        Modality="MR", SeriesDescription="t1_mprage", StudyDate=""
+    )
+
+    assert create_rtstruct_id(metadata) == f"T1M_{FALLBACK_DATE_STR}"


### PR DESCRIPTION
## Summary
- add a deterministic fallback string for missing or invalid study dates
- make RTSTRUCT ID generation tolerant of missing StudyDate metadata
- cover invalid and missing StudyDate inputs with unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d24da2ed00832fb93f0d48f90552b1