### PR TITLE
Align registration confirmation messaging

### DIFF
--- a/register.py
+++ b/register.py
@@ -750,20 +750,21 @@ def perform_registration(current_directory, patient_id, rtplan_label,
         pad_slices=pad_slices,
     )
 
+    historical_costs = _load_series_cost_history(fixed_series_description)
+    percentile = _compute_top_percentile(metric_value, historical_costs)
+    prompt_lines = [
+        "Accept registration result?",
+        f"Cost: {metric_value:.4f}",
+    ]
+    if percentile is not None:
+        prompt_lines.append(f"Top {percentile:.1f}% of registrations")
+    prompt_lines.append("Accept? (y/n): ")
+    prompt = "\n".join(prompt_lines)
+
     if confirm_fn is None:
-        historical_costs = _load_series_cost_history(fixed_series_description)
-        percentile = _compute_top_percentile(metric_value, historical_costs)
-        if percentile is not None:
-            prompt = (
-                "Registration cost: "
-                f"{metric_value:.4f} (top {percentile:.1f}% of registrations). "
-                "Accept? (y/n): "
-            )
-        else:
-            prompt = f"Registration cost: {metric_value:.4f}. Accept? (y/n): "
         registration_accepted = input(prompt) == "y"
     else:
-        registration_accepted = confirm_fn(metric_value)
+        registration_accepted = confirm_fn(metric_value, percentile)
 
     log_entry = {
         "patient_id": patient_id,

--- a/run_gui.py
+++ b/run_gui.py
@@ -479,8 +479,13 @@ def main():
         root.update_idletasks()
         try:
 
-            def confirm(cost_value):
-                msg = f"Accept registration result?\nCost: {cost_value:.4f}"
+            def confirm(cost_value, percentile):
+                details = [f"Cost: {cost_value:.4f}"]
+                if percentile is not None:
+                    details.append(
+                        f"Top {percentile:.1f}% of registrations"
+                    )
+                msg = "Accept registration result?\n" + "\n".join(details)
                 return messagebox.askyesno("Registration", msg)
 
             # Determine which series the user selected in the dropdowns


### PR DESCRIPTION
## Summary
- include percentile information when confirming registrations regardless of interface
- update the GUI confirmation dialog to mirror the CLI prompt contents

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d260d68b38832f9cd884ea6412dc97