### PR TITLE
Clear imaging list when refresh fails

### DIFF
--- a/run_gui.py
+++ b/run_gui.py
@@ -632,14 +632,8 @@ def main():
                 completion_callback(True)
 
         def handle_failure(err):
-            nonlocal (
-                series_info,
-                series_vars,
-                checkbox_texts,
-                references_map,
-                latest_imaging_uids,
-                imaging_refresh_in_progress,
-            )
+            nonlocal series_info, series_vars, checkbox_texts
+            nonlocal references_map, latest_imaging_uids, imaging_refresh_in_progress
             images_status.config(text="\u274C", fg="red")
             print(f"{get_datetime()} Failed to get images: {err}")
             series_info = {}

--- a/run_gui.py
+++ b/run_gui.py
@@ -632,9 +632,24 @@ def main():
                 completion_callback(True)
 
         def handle_failure(err):
-            nonlocal imaging_refresh_in_progress
+            nonlocal (
+                series_info,
+                series_vars,
+                checkbox_texts,
+                references_map,
+                latest_imaging_uids,
+                imaging_refresh_in_progress,
+            )
             images_status.config(text="\u274C", fg="red")
             print(f"{get_datetime()} Failed to get images: {err}")
+            series_info = {}
+            references_map = {}
+            latest_imaging_uids = set()
+            for widget in series_frame.winfo_children():
+                widget.destroy()
+            series_vars.clear()
+            checkbox_texts.clear()
+            update_dropdown()
             imaging_refresh_in_progress = False
             if completion_callback:
                 completion_callback(False)


### PR DESCRIPTION
## Summary
- reset the imaging series list and dropdown when fetching imaging fails
- ensure missing directories or other errors leave no stale series displayed

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd17631c60832faf0943d8ab69ff93