### PR TITLE
Auto-remove outdated imaging series

### DIFF
--- a/run_gui.py
+++ b/run_gui.py
@@ -1,3 +1,4 @@
+import datetime
 import os
 import sys
 import time
@@ -620,6 +621,16 @@ def main():
             latest_imaging_uids = set(imaging_uids)
             display_uids = imaging_uids + registration_uids
 
+            def is_series_older_than_today(uid: str) -> bool:
+                info = series_info.get(uid, {})
+                try:
+                    series_date = datetime.datetime.strptime(
+                        info.get("date", ""), "%Y%m%d"
+                    ).date()
+                except Exception:
+                    return False
+                return series_date < datetime.date.today()
+
             for widget in series_frame.winfo_children():
                 widget.destroy()
             series_vars.clear()
@@ -638,12 +649,22 @@ def main():
                 series_vars[uid] = var
                 checkbox_texts[uid] = text
 
+            outdated_uids = [uid for uid in display_uids if is_series_older_than_today(uid)]
+
+            for uid in outdated_uids:
+                series_vars[uid].set(True)
+
             update_dropdown()
             images_status.config(text="\u2705", fg="green")
             end_time = time.time()
             print(f"{get_datetime()} Getting the images {end_time - start_time:.2f} seconds")
             print(f"{get_datetime()} DONE\n")
             imaging_refresh_in_progress = False
+            if outdated_uids:
+                print(
+                    f"{get_datetime()} Auto-deleting {len(outdated_uids)} series older than today."
+                )
+                root.after(0, on_cleanup)
             if completion_callback:
                 completion_callback(True)
 

--- a/run_gui.py
+++ b/run_gui.py
@@ -594,7 +594,12 @@ def main():
 
     imaging_refresh_in_progress = False
 
-    def on_get_images(completion_callback=None):
+    def on_get_images(
+        completion_callback=None,
+        *,
+        skip_outdated_cleanup: bool = False,
+        cleanup_success: bool = True,
+    ):
         """Refresh imaging list, creating empty RTSTRUCTs for orphan studies."""
 
         print(f"{get_datetime()} Getting images from {input_dir}...")
@@ -660,13 +665,13 @@ def main():
             print(f"{get_datetime()} Getting the images {end_time - start_time:.2f} seconds")
             print(f"{get_datetime()} DONE\n")
             imaging_refresh_in_progress = False
-            if outdated_uids:
+            if outdated_uids and not skip_outdated_cleanup:
                 print(
                     f"{get_datetime()} Auto-deleting {len(outdated_uids)} series older than today."
                 )
                 on_cleanup(completion_callback=completion_callback)
             elif completion_callback:
-                completion_callback(True)
+                completion_callback(cleanup_success)
 
         def handle_failure(err):
             nonlocal series_info, series_vars, checkbox_texts
@@ -862,7 +867,11 @@ def main():
                     text="\u2705" if success else "\u274C",
                     fg="green" if success else "red",
                 )
-                on_get_images(completion_callback=completion_callback)
+                on_get_images(
+                    completion_callback=completion_callback,
+                    skip_outdated_cleanup=not success,
+                    cleanup_success=success,
+                )
 
             run_on_tk_thread(finalize)
 

--- a/run_gui.py
+++ b/run_gui.py
@@ -664,8 +664,8 @@ def main():
                 print(
                     f"{get_datetime()} Auto-deleting {len(outdated_uids)} series older than today."
                 )
-                root.after(0, on_cleanup)
-            if completion_callback:
+                on_cleanup(completion_callback=completion_callback)
+            elif completion_callback:
                 completion_callback(True)
 
         def handle_failure(err):
@@ -821,7 +821,7 @@ def main():
     # Delete selected series button
     cleanup_status = tk.Label(root, text="", font=("Helvetica", 14))
 
-    def on_cleanup():
+    def on_cleanup(*, completion_callback=None):
         cleanup_status.config(text="\u23F3", fg="orange")  # hourglass
         root.update_idletasks()
 
@@ -862,7 +862,7 @@ def main():
                     text="\u2705" if success else "\u274C",
                     fg="green" if success else "red",
                 )
-                on_get_images()
+                on_get_images(completion_callback=completion_callback)
 
             run_on_tk_thread(finalize)
 


### PR DESCRIPTION
## Summary
- automatically flag imaging and registration series older than the current day during imaging refresh
- invoke existing cleanup workflow to remove outdated series while leaving today's data untouched

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692573854184832f83aed4659624c669)